### PR TITLE
feat: Implement TaskService and CreateTaskEndpoint for task creation

### DIFF
--- a/Endpoints/CreateTaskEndpoint.cs
+++ b/Endpoints/CreateTaskEndpoint.cs
@@ -1,0 +1,32 @@
+using FastEndpoints;
+using TaskManagerAPI.DomainTransferObjects;
+using TaskManagerAPI.Mappers;
+using TaskManagerAPI.Services;
+
+namespace TaskManagerAPI.Endpoints;
+
+public class CreateTaskEndpoint : Endpoint<CreateTaskRequest, TaskResponse>
+{
+    public ITaskService TaskService { get; set; } // dependency injection
+
+    public override void Configure()
+    {
+        Post("/api/tasks");
+        AllowAnonymous();
+    }
+
+    public override async Task HandleAsync(CreateTaskRequest req, CancellationToken ct)
+    {
+        // maps request DTO to my domain entity using the mapper I created 
+        var taskEntity = TaskMapper.toEntity(req);
+        
+        //use the injected service to create the task
+        taskEntity = await TaskService.CreateTaskAsync(taskEntity);
+        
+        // map the domain entity back to a response DTO
+        var response = TaskMapper.fromEntity(taskEntity);
+        
+        await SendOkAsync(response, ct);
+    }
+    
+}

--- a/Services/ITaskService.cs
+++ b/Services/ITaskService.cs
@@ -1,0 +1,9 @@
+using TaskManagerAPI.DomainTransferObjects;
+using TaskManagerAPI.Entities;
+
+namespace TaskManagerAPI.Services;
+
+public interface ITaskService
+{
+    Task<TaskEntity> CreateTaskAsync(TaskEntity task);
+}

--- a/Services/TaskService.cs
+++ b/Services/TaskService.cs
@@ -1,0 +1,17 @@
+using TaskManagerAPI.Entities;
+
+namespace TaskManagerAPI.Services;
+
+public class TaskService : ITaskService
+{
+    // using an in-memory storage 
+    private readonly List<TaskEntity> _tasks = new();
+
+    public Task<TaskEntity> CreateTaskAsync(TaskEntity task)
+    {
+        task.TaskId = Guid.NewGuid();
+        _tasks.Add(task);
+        return Task.FromResult(task);
+    }
+
+}

--- a/TaskManagerAPI.csproj
+++ b/TaskManagerAPI.csproj
@@ -13,8 +13,4 @@
         <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2"/>
     </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Mappers\" />
-    </ItemGroup>
-
 </Project>


### PR DESCRIPTION
- Added TaskService using in-memory storage to create tasks with unique TaskIds.
- Implemented CreateTaskEndpoint to handle POST /api/tasks, mapping the CreateTaskRequest DTO to a TaskEntity using TaskMapper, then mapping back to a TaskResponse.
- Configured dependency injection for ITaskService in the endpoint.